### PR TITLE
Fix/113 플로깅 인증 실패 버그 수정

### DIFF
--- a/src/main/java/glue/Gachi_Sanchaek/walk/entity/WalkRecord.java
+++ b/src/main/java/glue/Gachi_Sanchaek/walk/entity/WalkRecord.java
@@ -66,4 +66,8 @@ public class WalkRecord {
     @Enumerated(EnumType.STRING)
     @Column(name="qr_stage")
     private QrStage qrStage = QrStage.UNVERIFIED;
+
+    @Column(name = "plogging_verified")
+    private Boolean ploggingVerified = false;
+
 }

--- a/src/main/java/glue/Gachi_Sanchaek/walk/service/RewardService.java
+++ b/src/main/java/glue/Gachi_Sanchaek/walk/service/RewardService.java
@@ -27,7 +27,7 @@ public class RewardService {
     public WalkEndResponse finalizeWalk(Long userId, WalkRecord walk, String message,
                                         Double totalDistance, Integer totalMinutes){
 
-        Long reward = Long.valueOf(calculateReward(walk.getWalkType(),totalDistance));
+        Long reward = Long.valueOf(calculateReward(walk,totalDistance));
 
         //인증 성공 시 - WalkRecord 업데이트
         walk.setStatus(WalkStatus.FINISHED);
@@ -81,15 +81,22 @@ public class RewardService {
     }
 
     // 리워드 계산
-    private int calculateReward(String walkType, double distanceKm){
+    private int calculateReward(WalkRecord walk, double distanceKm){
         //거리 기반 기본 포인트 : 1km당 100점 (반올림)
         int basePoints = (int)Math.round(distanceKm*100);
 
         //산책 타입에 따른 추가 포인트
-        int bonusPoints = switch(walkType.toUpperCase()){
+        int bonusPoints = switch(walk.getWalkType().toUpperCase()){
             case "SENIOR" -> 400;
             case "DOG" -> 300;
-            case "PLOGGING" -> 200;
+            case "PLOGGING" -> {
+                if(Boolean.TRUE.equals(walk.getPloggingVerified())){
+                    yield 200;
+                }
+                else{
+                    yield 0;
+                }
+            }
             default -> 0;
         };
         return basePoints + bonusPoints;

--- a/src/main/java/glue/Gachi_Sanchaek/walk/service/VerificationService.java
+++ b/src/main/java/glue/Gachi_Sanchaek/walk/service/VerificationService.java
@@ -78,14 +78,25 @@ public class VerificationService {
             throw new IllegalArgumentException("진행 중인 산책만 플로깅 인증이 가능합니다.");
         }
 
+        //이미 인증 성공한 경우
+        if(Boolean.TRUE.equals(walk.getPloggingVerified())){
+            return new VerificationResponse(
+                    walk.getId(),false,"이미 플로깅 인증이 완료되었습니다"
+            );
+        }
         //이미지 AI 분석
         int trashCount = geminiWalkService.countTrashImage(image);
 
-        if (trashCount < 10)
+        //실패한경우
+        if (trashCount < 10) {
             return new VerificationResponse(walk.getId(),
-                    false, "플로깅 인증 실패 (" + trashCount + "개 감지됨)");
+                    false, "플로깅 인증하기에 쓰레기가 부족합니다. (" + trashCount + "개 감지)");
+        }
+
+        //성공한 경우 - DB에 저장
+        walk.setPloggingVerified(true);
 
         return new VerificationResponse(walk.getId(),
-                true, "플로깅 인증 성공 (" + trashCount + "개 감지됨)");
+                true, "플로깅 인증에 성공했습니다 (" + trashCount + "개 감지)");
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number 
- #113 
- close #113 

## 🪐 작업 내용
- 플로깅 인증 실패 시 비정상적으로 리워드가 누적되는 버그를 수정했습니다
- 플로깅 인증 상태를 저장하는 plogging_verified 필드를 WalkRecord에 추가했습니다 (ERD 반영 완료)
ploggingVerified 플래그로 성공 여부 저장
RewardService : 플로깅 리워드는 ploggingVerified == true 일 때만 지급
-> 플로깅 인증을 여러 번 시도해도 성공한 경우에만 1회 리워드 지급