### PR TITLE
Feat/147 ranking

### DIFF
--- a/src/main/java/glue/Gachi_Sanchaek/common/initialization/InitializationRunner.java
+++ b/src/main/java/glue/Gachi_Sanchaek/common/initialization/InitializationRunner.java
@@ -11,13 +11,11 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class InitializationRunner implements ApplicationRunner {
 
-    private final StampInitializer stampInitializer;
-    private final AdminInitializer adminInitializer;
+    private final UserInit userInit;
 
     @Override
     public void run(ApplicationArguments args) {
-        stampInitializer.init();
-        adminInitializer.init();
+//        userInit.init();
         log.info("Initialization complete.");
     }
 }

--- a/src/main/java/glue/Gachi_Sanchaek/common/initialization/StampInitializer.java
+++ b/src/main/java/glue/Gachi_Sanchaek/common/initialization/StampInitializer.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Profile("dev")
+//@Profile("dev")
 public class StampInitializer {
 
     private static final String STAMP_RESOURCE_PATH = "classpath:/static/bonggong/*";

--- a/src/main/java/glue/Gachi_Sanchaek/common/initialization/UserInit.java
+++ b/src/main/java/glue/Gachi_Sanchaek/common/initialization/UserInit.java
@@ -1,0 +1,44 @@
+package glue.Gachi_Sanchaek.common.initialization;
+
+import glue.Gachi_Sanchaek.domain.login.dto.UserJoinDto;
+import glue.Gachi_Sanchaek.domain.pointLog.enums.WalkType;
+import glue.Gachi_Sanchaek.domain.user.entity.User;
+import glue.Gachi_Sanchaek.domain.user.repository.UserRepository;
+import glue.Gachi_Sanchaek.domain.user.service.UserService;
+import glue.Gachi_Sanchaek.domain.walk.dto.WalkEndRequest;
+import glue.Gachi_Sanchaek.domain.walk.dto.WalkResponse;
+import glue.Gachi_Sanchaek.domain.walk.dto.WalkStartRequest;
+import glue.Gachi_Sanchaek.domain.walk.service.WalkRecordService;
+import glue.Gachi_Sanchaek.domain.walk.service.WalkService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserInit {
+    private final UserRepository userRepository;
+    private final WalkService walkService;
+    private final UserService userService;
+
+    public void init(){
+
+        for(int i=0;i<100000;i++){
+            User user = userRepository.save(new User(new UserJoinDto((long) i, "user" + i)));
+            WalkStartRequest walkStartRequest = new WalkStartRequest(null, WalkType.NORMAL);
+            WalkResponse walkResponse = walkService.startWalk(walkStartRequest, user.getId());
+            WalkEndRequest walkEndRequest
+                    = new WalkEndRequest(walkResponse.getWalkId(), Math.random()*1000, (int) (Math.random()*1000));
+            walkService.endWalk(user.getId(),walkEndRequest);
+            if(i%1000==0){
+                System.out.println("user"+i+" complete");
+            }
+        }
+
+
+
+    }
+
+
+}

--- a/src/main/java/glue/Gachi_Sanchaek/domain/ranking/entity/Ranking.java
+++ b/src/main/java/glue/Gachi_Sanchaek/domain/ranking/entity/Ranking.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -19,7 +20,9 @@ import lombok.Setter;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
-@Table(name = "rankings")
+@Table(name = "rankings", indexes = {
+        @Index(name = "idx_rankings_covering", columnList = "rank_period, point DESC, updated_at, user_id")
+})
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/glue/Gachi_Sanchaek/domain/ranking/repository/RankingRepository.java
+++ b/src/main/java/glue/Gachi_Sanchaek/domain/ranking/repository/RankingRepository.java
@@ -12,39 +12,48 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
-    String CTE_RANKING = """
-        WITH RankedUsers AS (
-            SELECT 
-                r.user_id,
-                u.nickname,
-                u.profile_image_url AS profileImageUrl,
-                r.point,
-                r.updated_at AS updatedAt,
-                RANK() OVER (ORDER BY r.point DESC) AS ranking
-            FROM rankings r
-            JOIN users u ON u.id = r.user_id
-            WHERE r.rank_period = :period
-                AND u.is_deleted = false
-        )
-    """;
-
-
-    @Query(value = CTE_RANKING + """
-        SELECT nickname, profileImageUrl, point, ranking
-        FROM RankedUsers
-        ORDER BY ranking ASC, updatedAt asc
+    @Query(value = """
+        SELECT 
+            u.nickname, 
+            u.profile_image_url AS profileImageUrl, 
+            filtered_r.point, 
+            RANK() OVER (ORDER BY filtered_r.point DESC) as ranking
+        FROM (
+            SELECT user_id, point, updated_at
+            FROM rankings
+            WHERE rank_period = :period
+            ORDER BY point DESC
+            LIMIT 50  -- 탈퇴한 유저를 고려하여 10개보다 여유 있게 조회 (인덱스 활용)
+        ) filtered_r
+        JOIN users u ON u.id = filtered_r.user_id
+        WHERE u.is_deleted = false
+        ORDER BY filtered_r.point DESC, filtered_r.updated_at ASC
         LIMIT 10
         """, nativeQuery = true)
     List<RankingResponseDto> findTop10ByPeriod(@Param("period") int period);
 
 
-    @Query(value = CTE_RANKING + """
-        SELECT nickname, profileImageUrl, point, ranking
-        FROM RankedUsers
-        WHERE user_id = :userId
+    @Query(value = """
+        SELECT 
+            sub.nickname, 
+            sub.profileImageUrl, 
+            sub.point, 
+            sub.ranking
+        FROM (
+            SELECT 
+                r.user_id,
+                u.nickname,
+                u.profile_image_url AS profileImageUrl,
+                r.point,
+                RANK() OVER (ORDER BY r.point DESC) AS ranking
+            FROM rankings r
+            JOIN users u ON u.id = r.user_id
+            WHERE r.rank_period = :period
+                AND u.is_deleted = false
+        ) sub
+        WHERE sub.user_id = :userId
     """, nativeQuery = true)
     RankingResponseDto findDtoByPeriodAndUserId(@Param("period") int period, @Param("userId") Long userId);
-
 
 
     Optional<Ranking> findByRankPeriodAndUserId(int period, Long userId);

--- a/src/main/java/glue/Gachi_Sanchaek/domain/user/service/UserService.java
+++ b/src/main/java/glue/Gachi_Sanchaek/domain/user/service/UserService.java
@@ -6,8 +6,15 @@ import glue.Gachi_Sanchaek.domain.user.dto.UserJoinRequestDto;
 import glue.Gachi_Sanchaek.domain.user.dto.UserUpdateRequestDto;
 import glue.Gachi_Sanchaek.domain.user.entity.User;
 import glue.Gachi_Sanchaek.domain.user.repository.UserRepository;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     public User findById(Long userId){
         return userRepository.findByIdAndDeletedFalse(userId)

--- a/src/main/java/glue/Gachi_Sanchaek/domain/walk/dto/WalkEndRequest.java
+++ b/src/main/java/glue/Gachi_Sanchaek/domain/walk/dto/WalkEndRequest.java
@@ -1,10 +1,12 @@
 package glue.Gachi_Sanchaek.domain.walk.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class WalkEndRequest {
     private Long walkId;
     private Double totalDistance;

--- a/src/main/java/glue/Gachi_Sanchaek/domain/walk/dto/WalkStartRequest.java
+++ b/src/main/java/glue/Gachi_Sanchaek/domain/walk/dto/WalkStartRequest.java
@@ -1,11 +1,13 @@
 package glue.Gachi_Sanchaek.domain.walk.dto;
 
 import glue.Gachi_Sanchaek.domain.pointLog.enums.WalkType;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class WalkStartRequest {
     private Long recommendationId;
     private WalkType walkType;


### PR DESCRIPTION
<!-- 
  Assignees : 자기 자신
  Reviewers : 팀원 중 한명 선택
-->

## 🛰️ Issue Number 
<!-- 이슈 번호를 작성해주세요. ex) #13 -->
<!-- issue도 함께 close 하고 싶다면 close #이슈번호 로 작성해주세요. -->
- #147 
- close #147 

## 🪐 작업 내용
<!-- 작업 내용에 대해 설명해주세요 -->
- rankings 테이블에서 (rank_period, point DESC, updated_at, user_id)로 인덱스를 걸고, 기존 쿼리를 개선했습니다.
    - rankings 테이블은 삽입/수정 연산보다 조회 연산이 더 많이 수행됩니다. 
    - 이에 따라 커버링 인덱스를 통해 조회 성능을 극대화 했습니다. 
- 기존 순위표 조회 API의 평균 응답 속도를 2.46s -> 4.77ms로 515배의 성능 개선을 이루었습니다. 
- redis 도입 없이도 충분한 응답 속도를 보였고, 이에 따라 redis 캐시 계층은 이용하지 않았습니다. 

## 📚 공유 사항
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
<!-- 리뷰어가 알고 있어야 하는 내용이 있다면 적어주세요. -->